### PR TITLE
markdown support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+gem 'kramdown'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.2)
+    kramdown (1.6.0)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -165,6 +166,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)
   jquery-rails
+  kramdown
   neat
   rails (= 4.2.0)
   sass-rails (~> 5.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def markdown_format(text)
+    Kramdown::Document.new(text).to_html.html_safe
+  end
 end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -9,7 +9,7 @@
   <% @articles.each do |article| %>
     <tr>
       <td><%= article.title %></td>
-      <td><%= article.text %></td>
+      <td><%= markdown_format(article.text) %></td>
       <td><%= link_to 'show', article_path(article) %></td>
       <td><%= link_to 'edit', edit_article_path(article) %></td>
       <td><%= link_to 'remove', article_path(article), method: :delete, data: { confirm: 'Really?' } %></td>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -5,7 +5,7 @@
 
 <p>
   <strong>Text:</strong>
-  <%= @article.text %>
+  <%= markdown_format(@article.text) %>
 </p>
 
 <h2>Comments</h2>


### PR DESCRIPTION
This adds markdown support. When you write new articles, they can be in markdown format. The articles on the index and show pages will be markdown formatted when they're displayed. 